### PR TITLE
docs: update README with pipeline overview and ReelMistri origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,29 @@
 
 Open-source AI pipeline that turns any topic into a fully rendered YouTube Short — research, script, voiceover, images, captions, and video assembly in one command.
 
-OpenReels is a CLI that generates complete YouTube Shorts from a single topic. It researches the web, writes a script, generates voiceover with word-level timestamps, creates AI images, renders animated captions, and assembles everything into a vertical video — all in one command. Supports multiple languages, visual style archetypes, and an AI critic that re-runs the pipeline if quality is below threshold.
+## What it does
+
+Give it a topic. It handles everything else:
+
+1. **Research** — web search to ground the script in real facts
+2. **Script** — writes a punchy, language-aware short-form script
+3. **Voiceover** — generates TTS audio with word-level timestamps
+4. **Visuals** — creates AI images matched to each scene
+5. **Captions** — renders styled, animated captions with proper Unicode/CJK/RTL support
+6. **Assembly** — composites everything into a vertical MP4 via Remotion
+7. **Critique** — an AI critic scores the output and re-runs the pipeline if quality is below threshold
+
+```
+openreels generate "OpenAI shut down Sora to redirect compute into robotics — why they killed their most hyped product" --lang en --archetype dramatic_caricature
+```
+
+Topic in → MP4 out. No editing.
+
+## Background
+
+OpenReels is a full rewrite and open-source rebrand of [ReelMistri](https://github.com/tsensei/ReelMistri/) — a CLI pipeline originally built for Bangla-language YouTube Shorts automation. ReelMistri proved the concept: one command, fully produced video, language-aware scripts, culturally coherent visuals, proper Bengali text rendering.
+
+The rewrite moves from Python to TypeScript for native [Remotion](https://www.remotion.dev/) integration — cleaner video rendering, better developer experience, no Python-to-TypeScript bridge.
 
 ## Status
 


### PR DESCRIPTION
## Summary

- Expands the README with a full description of the pipeline steps (research → script → voiceover → visuals → captions → assembly → critique)
- Adds an example command showing the CLI interface
- Documents the ReelMistri origin and the reason for the Python → TypeScript rewrite (native Remotion integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)